### PR TITLE
Fix .gitignore and remove merge artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,8 @@
-<<<<<<< HEAD
-# OSX
-#
+# macOS
 .DS_Store
 
-# Xcode
-#
-build/
+# iOS / Xcode
+ios/build/
 *.pbxuser
 !default.pbxuser
 *.mode1v3
@@ -17,114 +14,53 @@ build/
 xcuserdata
 *.xccheckout
 *.moved-aside
-DerivedData
+DerivedData/
 *.hmap
 *.ipa
 *.xcuserstate
 **/.xcode.env.local
+ios/Pods/
 
-# Android/IntelliJ
-#
-build/
-.idea
-.gradle
-local.properties
+# Android / IntelliJ
+android/.gradle/
+android/.idea/
+android/local.properties
 *.iml
 *.hprof
-.cxx/
+android/.cxx/
 *.keystore
 !debug.keystore
 .kotlin/
+android/app/build/
 
-# node.js
-#
+# Node
 node_modules/
-npm-debug.log
-yarn-error.log
+npm-debug.log*
+yarn-error.log*
 
 # fastlane
-#
-# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
-# screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://docs.fastlane.tools/best-practices/source-control/
-
 **/fastlane/report.xml
 **/fastlane/Preview.html
 **/fastlane/screenshots
 **/fastlane/test_output
 
-# Bundle artifact
+# Bundle artifacts
 *.jsbundle
 
-# Ruby / CocoaPods
+# CocoaPods
 **/Pods/
 /vendor/bundle/
 
-# Temporary files created by Metro to check the health of the file watcher
+# Metro health check
 .metro-health-check*
 
-# testing
-/coverage
+# Testing output
+coverage/
 
-# Yarn
+# Yarn v2
 .yarn/*
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
-=======
-# http://www.gnu.org/software/automake
-
-Makefile.in
-/ar-lib
-/mdate-sh
-/py-compile
-/test-driver
-/ylwrap
-.deps/
-.dirstamp
-
-# http://www.gnu.org/software/autoconf
-
-autom4te.cache
-/autoscan.log
-/autoscan-*.log
-/aclocal.m4
-/compile
-/config.cache
-/config.guess
-/config.h.in
-/config.log
-/config.status
-/config.sub
-/configure
-/configure.scan
-/depcomp
-/install-sh
-/missing
-/stamp-h1
-
-# https://www.gnu.org/software/libtool/
-
-/ltmain.sh
-
-# http://www.gnu.org/software/texinfo
-
-/texinfo.tex
-
-# http://www.gnu.org/software/m4/
-
-m4/libtool.m4
-m4/ltoptions.m4
-m4/ltsugar.m4
-m4/ltversion.m4
-m4/lt~obsolete.m4
-
-# Generated Makefile
-# (meta build system like autotools,
-# can automatically generate from config.status script
-# (which is called by configure script))
-Makefile
->>>>>>> 05cbfb1abbafcebc5bbbd5d7ec21fb7fdfb9a7d7


### PR DESCRIPTION
## Summary
- clean up `.gitignore`
- consolidate ignore rules for React Native Android/iOS builds and node modules

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685aedd063a0832691d1e182dc7c1056