### PR TITLE
Add responsive scaling helper

### DIFF
--- a/assets/styles/globalStyle.js
+++ b/assets/styles/globalStyle.js
@@ -1,17 +1,22 @@
 import { StyleSheet } from 'react-native';
 import { getFontFamily } from '../fonts/helper';
+import {
+  horizontalScale,
+  verticalScale,
+  scaleFont,
+} from './scaling';
 
 const globalStyle = StyleSheet.create({
   header: {
     // marginLeft: 27,
     // marginRight: 17,
-    marginTop: 30,
+    marginTop: verticalScale(30),
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
   },
   messageIcon: {
-    padding: 14,
+    padding: horizontalScale(14),
     borderRadius: 100,
     backgroundColor: '#F9FAFB',
   },
@@ -19,23 +24,23 @@ const globalStyle = StyleSheet.create({
     backgroundColor: '#F35BAC',
     justifyContent: 'center',
     flexDirection: 'row',
-    width: 10,
-    height: 10,
+    width: horizontalScale(10),
+    height: verticalScale(10),
     borderRadius: 100,
     position: 'absolute',
-    right: 10,
-    top: 12,
+    right: horizontalScale(10),
+    top: verticalScale(12),
   },
   messageNumber: {
     color: '#FFFFFF',
-    fontSize: 6,
+    fontSize: scaleFont(6),
     fontFamily: getFontFamily('Inter', '600'),
   },
   userStoriesContainer: {
-    marginTop: 20,
+    marginTop: verticalScale(20),
   },
   userPostContainer: {
-    marginHorizontal: 24,
+    marginHorizontal: horizontalScale(24),
   },
 });
 

--- a/assets/styles/scaling.js
+++ b/assets/styles/scaling.js
@@ -1,0 +1,34 @@
+import { Dimensions, PixelRatio } from 'react-native';
+
+let DeviceInfo;
+try {
+  // Optional dependency. Tests might not have the native module available.
+  DeviceInfo = require('react-native-device-info');
+} catch (e) {
+  DeviceInfo = { isTablet: () => false };
+}
+
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+
+// Guideline sizes are based on standard ~5" screen mobile device
+const GUIDELINE_BASE_WIDTH = 375;
+const GUIDELINE_BASE_HEIGHT = 812;
+
+const scaleWidth = SCREEN_WIDTH / GUIDELINE_BASE_WIDTH;
+const scaleHeight = SCREEN_HEIGHT / GUIDELINE_BASE_HEIGHT;
+
+export const horizontalScale = size => size * scaleWidth;
+
+export const verticalScale = size => size * scaleHeight;
+
+export const scaleFont = size => {
+  const newSize = size * scaleWidth;
+  const adjustedSize = DeviceInfo.isTablet() ? newSize * 0.9 : newSize;
+  return Math.round(PixelRatio.roundToNearestPixel(adjustedSize));
+};
+
+export default {
+  horizontalScale,
+  verticalScale,
+  scaleFont,
+};

--- a/components/Title/style.js
+++ b/components/Title/style.js
@@ -1,11 +1,12 @@
 import { StyleSheet } from 'react-native';
 import { getFontFamily } from '../../assets/fonts/helper';
+import { scaleFont } from '../../assets/styles/scaling';
 
 const style = StyleSheet.create({
   title: {
     color: '#022150',
     fontFamily: getFontFamily('Inter', '600'),
-    fontSize: 24,
+    fontSize: scaleFont(24),
   },
 });
 

--- a/components/UserPost/style.js
+++ b/components/UserPost/style.js
@@ -1,11 +1,16 @@
 import { StyleSheet } from 'react-native';
 import { getFontFamily } from '../../assets/fonts/helper';
+import {
+  horizontalScale,
+  verticalScale,
+  scaleFont,
+} from '../../assets/styles/scaling';
 
 const style = StyleSheet.create({
   userContainer: { flexDirection: 'row' },
   userTextContainer: {
     justifyContent: 'center',
-    marginLeft: 10,
+    marginLeft: horizontalScale(10),
   },
   user: {
     flexDirection: 'row',
@@ -15,29 +20,29 @@ const style = StyleSheet.create({
   username: {
     color: '#000',
     fontFamily: getFontFamily('Inter', '600'), //this font weight should have been a string
-    fontSize: 16,
+    fontSize: scaleFont(16),
   },
   location: {
     color: '#79869F',
-    marginLeft: -4, //This is not really needed I just missed a space on location text right before the location prop, that is why we needed marginLeft
+    marginLeft: horizontalScale(-4), //This is not really needed I just missed a space on location text right before the location prop, that is why we needed marginLeft
     fontFamily: getFontFamily('Inter', '400'), //this font weight should have been a string
-    fontSize: 12,
-    marginTop: 5,
+    fontSize: scaleFont(12),
+    marginTop: verticalScale(5),
   },
   postImage: {
     alignItems: 'center',
-    marginVertical: 20,
+    marginVertical: verticalScale(20),
   },
   userPostContainer: {
-    marginTop: 35,
-    paddingBottom: 20,
+    marginTop: verticalScale(35),
+    paddingBottom: verticalScale(20),
     borderBottomWidth: 1,
     borderBottomColor: '#EFF2F6',
   },
-  userPostStats: { marginLeft: 10, flexDirection: 'row' },
+  userPostStats: { marginLeft: horizontalScale(10), flexDirection: 'row' },
   userPostStatButton: { flexDirection: 'row' },
-  userPostStatButtonRight: { flexDirection: 'row', marginLeft: 27 },
-  userPostStatText: { marginLeft: 3, color: '#79869F' },
+  userPostStatButtonRight: { flexDirection: 'row', marginLeft: horizontalScale(27) },
+  userPostStatText: { marginLeft: horizontalScale(3), color: '#79869F' },
 });
 
 export default style;

--- a/components/UserProfileImage/style.js
+++ b/components/UserProfileImage/style.js
@@ -1,10 +1,11 @@
 import { StyleSheet } from 'react-native';
+import { horizontalScale } from '../../assets/styles/scaling';
 
 const style = StyleSheet.create({
   userImageContainer: {
     borderColor: '#F35BAC',
     borderWidth: 1,
-    padding: 3,
+    padding: horizontalScale(3),
   },
 });
 

--- a/components/UserStory/style.js
+++ b/components/UserStory/style.js
@@ -1,19 +1,24 @@
 import { StyleSheet } from 'react-native';
 import { getFontFamily } from '../../assets/fonts/helper';
+import {
+  horizontalScale,
+  verticalScale,
+  scaleFont,
+} from '../../assets/styles/scaling';
 
 const style = StyleSheet.create({
   storyContainer: {
     alignItems: 'center',
-    marginRight: 20,
+    marginRight: horizontalScale(20),
   },
   firstName: {
     color: '#022150',
     textAlign: 'center',
     fontFamily: getFontFamily('Inter', 500),
-    fontSize: 14,
+    fontSize: scaleFont(14),
     lineHeight: 'normal',
-    letterSpacing: 0.14,
-    marginTop: 8,
+    letterSpacing: horizontalScale(0.14),
+    marginTop: verticalScale(8),
   },
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "prop-types": "^15.8.1",
         "react": "19.1.0",
         "react-native": "0.80.0",
+        "react-native-device-info": "^14.0.4",
         "react-native-svg": "^15.12.0"
       },
       "devDependencies": {
@@ -10701,6 +10702,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-device-info": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-14.0.4.tgz",
+      "integrity": "sha512-NX0wMAknSDBeFnEnSFQ8kkAcQrFHrG4Cl0mVjoD+0++iaKrOupiGpBXqs8xR0SeJyPC5zpdPl4h/SaBGly6UxA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": "*"
       }
     },
     "node_modules/react-native-svg": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prop-types": "^15.8.1",
     "react": "19.1.0",
     "react-native": "0.80.0",
+    "react-native-device-info": "^14.0.4",
     "react-native-svg": "^15.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add scaling.js in assets/styles for responsive measurements
- update style files to use new scaling helpers
- install react-native-device-info dependency
- gracefully handle missing device-info in tests

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685b0a03a3408326903b0da5cfd59655